### PR TITLE
Allow extension of JS modules in addition to JSON objects.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "scripts": {
     "test": "grunt test"
   },
+  "dependencies": {
+    "toSrc": "~0.1.3"
+  },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-clean": "~0.4.0",

--- a/readme.md
+++ b/readme.md
@@ -183,8 +183,8 @@ In order to extend and object deeply, add `deep` to the targets options:
 ```js
 grunt.initConfig({
   extend: {
-    deep: true,
     options: {
+      deep: true,
       defaults: {
         coffee: true,
         options: ['a', 'b', 'c']
@@ -193,6 +193,23 @@ grunt.initConfig({
     extendedConfig: {
       files: {
         'tmp/config-base.json': ['.config-base.json']
+      }
+    }
+  }
+});
+```
+
+#### CommonJS `require`-able extend
+In order to extend CommonJS modules, add `require` to the targets options and reference `.js` files:
+```js
+grunt.initConfig({
+  extend: {
+    options: {
+      require: true
+    },
+    extendedConfig: {
+      files: {
+        'tmp/config-base.js': ['.config-base.js']
       }
     }
   }

--- a/tasks/extend.js
+++ b/tasks/extend.js
@@ -42,7 +42,11 @@ module.exports = function(grunt) {
       grunt.verbose.writeflags(data, 'args:');
 
       grunt.util._.each(f.src, function (filename) {
-        data.push(grunt.file.readJSON(filename));
+        if (options.require && /\.js$/.test(filename)) {
+          data.push(require(process.cwd() +'/' + filename));
+        } else {
+          data.push(grunt.file.readJSON(filename));
+        }
       });
 
       if (options.deep) {
@@ -51,7 +55,14 @@ module.exports = function(grunt) {
         data = grunt.util._.extend.apply(grunt.util._, data);
       }
 
-      grunt.file.write(f.dest, JSON.stringify(data, null, 4));
+      if (options.require) {
+        var src = "module.exports = (function() {\n\tvar self = "
+                + require("toSrc")(data, 4)
+                + ";\n\treturn self;\n})();";
+        grunt.file.write(f.dest, src);
+      } else {
+        grunt.file.write(f.dest, JSON.stringify(data, null, 4));
+      }
       grunt.log.writeln('File "' + f.dest + '" created.');
     });
   });


### PR DESCRIPTION
This is useful (to me) for building a layered configuration modules incorporating both primitives and functions.

Here's an example to illustrate...
#### base-config.js

``` js
module.exports = (function() {
    var self = {
        company: {
            name: 'DEFAULT'
        },
        copyright: {
            year: '2011',
            message: function () {
                return 'Copyright ' + self.copyright.year + ' by ' + self.company.name + '. All rights reserved.';
            }
        }
    }
    return self;
})();
```
#### override-config.js

``` js
module.exports = (function() {
    var self = {
        company: {
            name: 'SomeCo'
        },
        copyright: {
            year: '2013'
        }
    }
    return self;
})();
```
#### Gruntfile.js

``` js
grunt.initConfig({
  extend: {
    options: {
      require: true
    },
    extendedConfig: {
      files: {
        'resulting-config.js': ['base-config.js,', 'override-config.js']
      }
    }
  }
});
```
#### resulting-config.js

``` js
module.exports = (function() {
    var self = {
        company: {
            name: 'SomeCo'
        },
        copyright: {
            year: '2013',
            message: function () {
                return 'Copyright ' + self.copyright.year + ' by ' + self.company.name + '. All rights reserved.';
            }
        }
    }
    return self;
})();
```
#### app.js

``` js
require('resulting-config.js').copyright.message(); // Copyright 2013 by SomeCo. All rights reserved.
```
